### PR TITLE
test(prayer): make prayer schedule test timezone-independent

### DIFF
--- a/__tests__/components/prayer-schedule-ui.test.tsx
+++ b/__tests__/components/prayer-schedule-ui.test.tsx
@@ -47,7 +47,9 @@ describe('PrayerScheduleUI', () => {
       require('@/hooks/use-media-query').useMediaQuery as jest.Mock
     ).mockReturnValue(true);
     // Mock date to a specific time for consistent results
-    jest.useFakeTimers().setSystemTime(new Date('2025-06-08T12:00:00'));
+    // FIX: Set the time in UTC to ensure the test is timezone-independent.
+    // 05:00 UTC is 12:00 WIB (Asia/Jakarta), which is during Zuhur time.
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-08T05:00:00.000Z'));
   });
 
   afterEach(() => {


### PR DESCRIPTION
The prayer schedule UI test was failing in the CI environment due to a timezone mismatch. The test was mocking the system time to 12:00, which was interpreted as 12:00 UTC on the GitHub runner. This caused the application, which operates in WIB (UTC+7), to calculate the current prayer incorrectly.

This commit fixes the test by setting the mock date to a specific UTC time (`05:00:00.000Z`) that corresponds to the intended local time (12:00 WIB). This ensures the test behaves consistently regardless of the runner's system timezone.